### PR TITLE
Refine flat config types

### DIFF
--- a/src/configs/flat/base.ts
+++ b/src/configs/flat/base.ts
@@ -1,4 +1,4 @@
-import type { ESLint } from "eslint";
+import type { ESLint, Linter } from "eslint";
 import * as parser from "toml-eslint-parser";
 export default [
   {
@@ -20,4 +20,4 @@ export default [
       "spaced-comment": "off",
     },
   },
-];
+] satisfies Linter.FlatConfig[];

--- a/src/configs/flat/recommended.ts
+++ b/src/configs/flat/recommended.ts
@@ -1,6 +1,7 @@
 // IMPORTANT!
 // This file has been automatically generated,
 // in order to update its content execute "npm run update"
+import type { Linter } from "eslint";
 import base from "./base";
 export default [
   ...base,
@@ -13,4 +14,4 @@ export default [
       "toml/vue-custom-block/no-parsing-error": "error",
     },
   },
-];
+] satisfies Linter.FlatConfig[];

--- a/src/configs/flat/standard.ts
+++ b/src/configs/flat/standard.ts
@@ -1,6 +1,7 @@
 // IMPORTANT!
 // This file has been automatically generated,
 // in order to update its content execute "npm run update"
+import type { Linter } from "eslint";
 import base from "./base";
 export default [
   ...base,
@@ -28,4 +29,4 @@ export default [
       "toml/vue-custom-block/no-parsing-error": "error",
     },
   },
-];
+] satisfies Linter.FlatConfig[];

--- a/tools/update-rulesets.ts
+++ b/tools/update-rulesets.ts
@@ -63,6 +63,7 @@ for (const rec of ["recommended", "standard"] as const) {
  * This file has been automatically generated,
  * in order to update its content execute "npm run update"
  */
+import type { Linter } from "eslint";
 import base from './base';
 export default [
   ...base,
@@ -83,7 +84,7 @@ export default [
         .join(",\n")}
     },
   }
-]
+] satisfies Linter.FlatConfig[]
 `;
 
   const filePath = path.resolve(__dirname, FLAT_RULESET_NAME[rec]);


### PR DESCRIPTION
Refines the types of the flat configs to conform to `@types/eslint`'s `Linter.FlatConfig`. Useful when used in a type checked project.

The only change in the resulting declaration is the values for the rules changing from `string` to `"error"` or `"off"`