### PR TITLE
feat: add all config

### DIFF
--- a/.changeset/calm-tomatoes-listen.md
+++ b/.changeset/calm-tomatoes-listen.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-toml": minor
+---
+
+Add an `all` configuration that enables every non-deprecated rule.

--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ This plugin provides configs:
 - `*.configs.base` ... Configuration to enable correct TOML parsing.
 - `*.configs.recommended` ... Above, plus rules to prevent errors or unintended behavior.
 - `*.configs.standard` ... Above, plus rules to enforce the common stylistic conventions.
+- `*.configs.all` ... Configuration to enable correct TOML parsing and all non-deprecated rules. This config is not recommended for production use because it may change with every minor release. Use at your own risk.
 
 For backward compatibility, you can also use the `flat/*` namespace:
 
+- `*.configs['flat/all']`
 - `*.configs['flat/base']`
 - `*.configs['flat/recommended']`
 - `*.configs['flat/standard']`

--- a/docs/rules/inline-table-curly-newline.md
+++ b/docs/rules/inline-table-curly-newline.md
@@ -48,7 +48,7 @@ val3 = {
 ```yaml
 toml/inline-table-curly-newline:
   - error
-  - always # or "never" 
+  - always # or "never"
   # or an object
   # - multiline: false
   #   minProperties: 2

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -42,9 +42,11 @@ This plugin provides configs:
 - `*.configs.base` ... Configuration to enable correct TOML parsing.
 - `*.configs.recommended` ... Above, plus rules to prevent errors or unintended behavior.
 - `*.configs.standard` ... Above, plus rules to enforce the common stylistic conventions.
+- `*.configs.all` ... Configuration to enable correct TOML parsing and all non-deprecated rules. This config is not recommended for production use because it may change with every minor release. Use at your own risk.
 
 For backward compatibility, you can also use the `flat/*` namespace:
 
+- `*.configs['flat/all']`
 - `*.configs['flat/base']`
 - `*.configs['flat/recommended']`
 - `*.configs['flat/standard']`

--- a/src/configs/flat/all.ts
+++ b/src/configs/flat/all.ts
@@ -1,0 +1,36 @@
+// IMPORTANT!
+// This file has been automatically generated,
+// in order to update its content execute "npm run update"
+import type { Linter } from "eslint";
+import base from "./base.ts";
+export default [
+  ...base,
+  {
+    rules: {
+      // eslint-plugin-toml rules
+      "toml/array-bracket-newline": "error",
+      "toml/array-bracket-spacing": "error",
+      "toml/array-element-newline": "error",
+      "toml/comma-style": "error",
+      "toml/indent": "error",
+      "toml/inline-table-curly-newline": "error",
+      "toml/inline-table-curly-spacing": "error",
+      "toml/inline-table-key-value-newline": "error",
+      "toml/key-spacing": "error",
+      "toml/keys-order": "error",
+      "toml/no-mixed-type-in-array": "error",
+      "toml/no-non-decimal-integer": "error",
+      "toml/no-space-dots": "error",
+      "toml/no-unreadable-number-separator": "error",
+      "toml/padding-line-between-pairs": "error",
+      "toml/padding-line-between-tables": "error",
+      "toml/precision-of-fractional-seconds": "error",
+      "toml/precision-of-integer": "error",
+      "toml/quoted-keys": "error",
+      "toml/spaced-comment": "error",
+      "toml/table-bracket-spacing": "error",
+      "toml/tables-order": "error",
+      "toml/vue-custom-block/no-parsing-error": "error",
+    },
+  },
+] satisfies Linter.Config[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import type { Linter } from "eslint";
 import type { RuleDefinition } from "@eslint/core";
 import type { RuleModule } from "./types.ts";
 import { rules as ruleList } from "./utils/rules.ts";
+import all from "./configs/flat/all.ts";
 import base from "./configs/flat/base.ts";
 import recommended from "./configs/flat/recommended.ts";
 import standard from "./configs/flat/standard.ts";
@@ -10,10 +11,12 @@ import type { TOMLSourceCode, TOMLLanguageOptions } from "./language/index.ts";
 import { TOMLLanguage } from "./language/index.ts";
 
 const configs = {
+  all: all as Linter.Config[],
   base: base as Linter.Config[],
   recommended: recommended as Linter.Config[],
   standard: standard as Linter.Config[],
   // Backward compatibility aliases
+  "flat/all": all as Linter.Config[],
   "flat/base": base as Linter.Config[],
   "flat/recommended": recommended as Linter.Config[],
   "flat/standard": standard as Linter.Config[],

--- a/tests/src/configs/all.ts
+++ b/tests/src/configs/all.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert";
+import plugin from "../../../src/index.ts";
+import { ESLint } from "eslint";
+
+const code = `foo = 0x10`;
+
+describe("`all` config", () => {
+  it("includes every non-deprecated rule", () => {
+    const allRules =
+      plugin.configs.all[plugin.configs.all.length - 1]?.rules ?? {};
+    const expectedRules = Object.entries(plugin.rules)
+      .filter(([, rule]) => !rule.meta?.deprecated)
+      .map(([ruleName]) => `toml/${ruleName}`)
+      .sort();
+    const configuredRules = Object.keys(allRules).sort();
+
+    assert.deepStrictEqual(configuredRules, expectedRules);
+    assert.strictEqual(allRules["toml/space-eq-sign"], undefined);
+  });
+
+  for (const configName of ["all", "flat/all"] as const) {
+    it(`\`${configName}\` config should enable all non-deprecated rules.`, async () => {
+      const linter = new ESLint({
+        overrideConfigFile: true,
+        overrideConfig: plugin.configs[configName],
+      });
+      const result = await linter.lintText(code, { filePath: "test.toml" });
+
+      assert.deepStrictEqual(
+        result[0].messages.map((message) => message.ruleId),
+        ["toml/no-non-decimal-integer"],
+      );
+    });
+  }
+});

--- a/tools/update-rulesets.ts
+++ b/tools/update-rulesets.ts
@@ -6,11 +6,12 @@ import { rules } from "./lib/load-rules.ts";
 const isWin = os.platform().startsWith("win");
 
 const FLAT_RULESET_NAME = {
+  all: "../src/configs/flat/all.ts",
   recommended: "../src/configs/flat/recommended.ts",
   standard: "../src/configs/flat/standard.ts",
 };
 
-for (const rec of ["recommended", "standard"] as const) {
+for (const rec of ["all", "recommended", "standard"] as const) {
   let content = `/*
  * IMPORTANT!
  * This file has been automatically generated,
@@ -26,9 +27,8 @@ export default [
       ${rules
         .filter(
           (rule) =>
-            rule.meta.docs.categories &&
             !rule.meta.deprecated &&
-            rule.meta.docs.categories.includes(rec),
+            (rec === "all" || rule.meta.docs.categories?.includes(rec)),
         )
         .map((rule) => {
           const conf = rule.meta.docs.default || "error";


### PR DESCRIPTION
Closes #252.

## Summary

- generate an `all` config containing every non-deprecated TOML rule
- expose it as both `configs.all` and the backward-compatible `configs["flat/all"]` alias
- document the risk of automatically enabling rules added in future minor releases
- add complete-set and runtime tests plus a minor changeset

## Validation

- `npm run update` (idempotent)
- `npm run lint`
- `npm run lint:ts`
- `npm run build`
- `npm test` (1026 passing)
- `npm run docs:build`
- `git diff --check`