### PR TITLE
fix CI npm install

### DIFF
--- a/.github/workflows/GHPages.yml
+++ b/.github/workflows/GHPages.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
       # npm 10's Arborist crashes on tsdown's nested optional peer dependencies.
       # npm 11.10.1+ includes the upstream fix: https://github.com/npm/cli/pull/8981
       - name: Use npm 11.18.0

--- a/.github/workflows/GHPages.yml
+++ b/.github/workflows/GHPages.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - uses: actions/setup-node@v6
+      # npm 10's Arborist crashes on tsdown's nested optional peer dependencies.
+      # npm 11.10.1+ includes the upstream fix: https://github.com/npm/cli/pull/8981
+      - name: Use npm 11.18.0
+        run: npm install --global npm@11.18.0
       - name: Install Packages
         run: npm install
       - name: Build

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
+      # npm 10's Arborist crashes on tsdown's nested optional peer dependencies.
+      # npm 11.10.1+ includes the upstream fix: https://github.com/npm/cli/pull/8981
+      - name: Use npm 11.18.0
+        run: npm install --global npm@11.18.0
       - name: Install Packages
         run: npm install
       - name: Lint
@@ -30,6 +34,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+      # npm 10's Arborist crashes on tsdown's nested optional peer dependencies.
+      # npm 11.10.1+ includes the upstream fix: https://github.com/npm/cli/pull/8981
+      - name: Use npm 11.18.0
+        run: npm install --global npm@11.18.0
       - name: Set ESLint Version
         run: npm install eslint@${{ matrix.eslint }}
       - name: Install Packages

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
       # npm 10's Arborist crashes on tsdown's nested optional peer dependencies.
       # npm 11.10.1+ includes the upstream fix: https://github.com/npm/cli/pull/8981
       - name: Use npm 11.18.0

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -32,6 +32,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: lts/*
+      # npm 10's Arborist crashes on tsdown's nested optional peer dependencies.
+      # npm 11.10.1+ includes the upstream fix: https://github.com/npm/cli/pull/8981
+      - name: Use npm 11.18.0
+        run: npm install --global npm@11.18.0
       - name: Install Dependencies
         run: npm install
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/checkout@v7
       - name: Setup node
         uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
       # npm 10's Arborist crashes on tsdown's nested optional peer dependencies.
       # npm 11.10.1+ includes the upstream fix: https://github.com/npm/cli/pull/8981
       - name: Use npm 11.18.0

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,6 +12,10 @@ jobs:
         uses: actions/checkout@v7
       - name: Setup node
         uses: actions/setup-node@v6
+      # npm 10's Arborist crashes on tsdown's nested optional peer dependencies.
+      # npm 11.10.1+ includes the upstream fix: https://github.com/npm/cli/pull/8981
+      - name: Use npm 11.18.0
+        run: npm install --global npm@11.18.0
       - name: Install deps
         run: npm install
       - name: Format


### PR DESCRIPTION
## Summary

- configure the lint, GitHub Pages, and format jobs to use setup-node's LTS installation, matching the existing release workflow
- install npm 11.18.0 before project dependencies in the CI, GitHub Pages, release, and format workflows
- document why the npm pin is required and link to the upstream Arborist fix

## Root cause

Fresh installs resolve `tsdown`'s optional `@vitejs/devtools` peer to a nested optional-peer graph that crashes npm 10 with `Cannot read properties of null (reading 'edgesOut')`. This surfaced without a repository dependency change because package lock generation is disabled. npm 11.10.1 and later include the upstream `peerOptional` resolution fix.

Jobs that did not specify `node-version` kept the runner's system Node.js installation, so updating npm globally attempted to write under the read-only `/usr/local` prefix. Selecting `lts/*` makes those jobs use setup-node's managed installation, as the successful test matrix already does.

## Impact

All workflows that install project dependencies now select a managed Node.js version before pinning npm. Dependency installation therefore uses the same fixed npm version across the supported Node.js matrix instead of depending on the npm version bundled with each Node.js release.

## Validation

- Node 20.19.5, 22.23.1, and 24.18.0 with npm 11.18.0
- ESLint 9 and 10 install flows on each Node.js version
- `npm test` — 1026 passing in all six matrix combinations
- `npm run lint`
- `npm run lint:ts`
- `npm run docs:build`
- workflow YAML parse and Prettier check
- `git diff --check`
