### PR TITLE
Fix docs build with pako 3

### DIFF
--- a/docs/.vitepress/theme/components/state/deserialize.js
+++ b/docs/.vitepress/theme/components/state/deserialize.js
@@ -1,4 +1,4 @@
-import pako from "pako";
+import { inflate } from "pako";
 
 /**
  * Deserialize a given serialized string then update this object.
@@ -21,16 +21,10 @@ export function deserializeState(serializedString) {
       let error;
       for (const fn of [
         () => {
-          const uint8Arr = pako.inflate(
+          const uint8Arr = inflate(
             Uint8Array.from(decodedText, (c) => c.charCodeAt(0)),
           );
           const jsonText = new TextDecoder().decode(uint8Arr);
-          return JSON.parse(jsonText);
-        },
-        () => {
-          const jsonText = pako.inflate(decodedText, {
-            to: "string",
-          });
           return JSON.parse(jsonText);
         },
         () => JSON.parse(decodedText),

--- a/docs/.vitepress/theme/components/state/serialize.js
+++ b/docs/.vitepress/theme/components/state/serialize.js
@@ -1,4 +1,4 @@
-import pako from "pako";
+import { deflate } from "pako";
 
 /**
  * Get only enabled rules to make the serialized data smaller.
@@ -27,7 +27,7 @@ export function serializeState(state) {
   const jsonString = JSON.stringify(saveData);
 
   const uint8Arr = new TextEncoder().encode(jsonString);
-  const compressedString = String.fromCharCode(...pako.deflate(uint8Arr));
+  const compressedString = String.fromCharCode(...deflate(uint8Arr));
   const base64 =
     (typeof window !== "undefined" && window.btoa(compressedString)) ||
     compressedString;


### PR DESCRIPTION
pako 3 removed its default ESM export, which causes the VitePress build to fail while bundling the playground state codec. Import `deflate` and `inflate` as named exports and remove the obsolete binary-string inflate fallback that pako no longer supports. The byte-based path continues to read compressed URLs, while the raw JSON fallback preserves older uncompressed links.

Verified with `npm run docs:build`, `npm run lint`, `npm run lint:ts`, `npm test` (1,026 passing), and a state codec smoke test covering Unicode compressed data and legacy uncompressed data.
